### PR TITLE
Fixed crash when attempting to kill target that doesn't exist

### DIFF
--- a/MIMWebClient/Core/Events/Fight2.cs
+++ b/MIMWebClient/Core/Events/Fight2.cs
@@ -231,7 +231,7 @@ namespace MIMWebClient.Core.Events
                 defendingPlayer =
                   room.players.Where(x => x.HitPoints > 0).ToList().FirstOrDefault(
                       x => x.Name.StartsWith(defender, StringComparison.CurrentCultureIgnoreCase))
-                  ?? room.mobs.Where(x => x.HitPoints > 0).ToList().First(x => x.Name.ToLower().Contains(defender.ToLower()));
+                  ?? room.mobs.Where(x => x.HitPoints > 0).ToList().FirstOrDefault(x => x.Name.ToLower().Contains(defender.ToLower()));
             }
             else
             {


### PR DESCRIPTION
"First" will raise an exception if there is no elements so replace with "FirstOrDefault".