### PR TITLE
Fix V3027 warning from PVS-Studio Static Analyzer

### DIFF
--- a/MIMWebClient/Core/Events/Craft.cs
+++ b/MIMWebClient/Core/Events/Craft.cs
@@ -165,7 +165,7 @@ namespace MIMWebClient.Core.Events
                 return;
             }
 
-            if (findCraft.CraftCommand == CraftType.Chop && craftType == null || findCraft == null && craftType == null)
+            if ((findCraft == null || findCraft.CraftCommand == CraftType.Chop) && craftType == null)
             {
                 HubContext.Instance.SendToClient("You can't craft that.", player.HubGuid);
                 return;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:
[V3027](https://www.viva64.com/ru/w/v3027/) The variable 'findCraft' was utilized in the logical expression before it was verified against null in the same logical expression. [Craft.cs 168](https://github.com/LiamKenneth/ArchaicQuest/blob/9e32db10c5478d5464fe8aa5ed6ccaf2163dc193/MIMWebClient/Core/Events/Craft.cs#L168)