### PR TITLE
Fix V3066 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/MIMWebClient/Core/Events/Fight2.cs
+++ b/MIMWebClient/Core/Events/Fight2.cs
@@ -114,7 +114,7 @@ namespace MIMWebClient.Core.Events
 
             AddFightersIdtoRoom(attacker, defender, room, false);
 
-            if (IsAlive(defender, attacker))
+            if (IsAlive(attacker, defender))
             {
                 if (attacker.Target == null)
                 {
@@ -123,7 +123,7 @@ namespace MIMWebClient.Core.Events
                 }
             }
 
-            StartFight(defender, attacker, room);
+            StartFight(attacker, defender, room);
 
         }
 
@@ -162,7 +162,7 @@ namespace MIMWebClient.Core.Events
                 if (!defender.ActiveFighting)
                 {
                     defender.ActiveFighting = true;
-                    Task.Run(() => HitTarget(defender, attacker, room, 2000));
+                    Task.Run(() => HitTarget(attacker, defender, room, 2000));
 
                 }
 

--- a/MIMWebClient/Core/Room/PlayerManager.cs
+++ b/MIMWebClient/Core/Room/PlayerManager.cs
@@ -23,7 +23,7 @@ namespace MIMWebClient.Core.Room
 
             var newRoomData = room;
 
-            Cache.updateRoom(oldRoomData, newRoomData);
+            Cache.updateRoom(newRoomData, oldRoomData);
         }
 
         public static void RemovePlayerFromRoom(Room room, Player player)
@@ -53,7 +53,7 @@ namespace MIMWebClient.Core.Room
 
             var newRoomData = room;
 
-            Cache.updateRoom(oldRoomData, newRoomData);
+            Cache.updateRoom(newRoomData, oldRoomData);
         }
 
         public static void RemoveMobFromRoom(Room room, Player mob)
@@ -68,7 +68,7 @@ namespace MIMWebClient.Core.Room
 
             var newRoomData = room;
 
-            Cache.updateRoom(oldRoomData, newRoomData);
+            Cache.updateRoom(newRoomData, oldRoomData);
 
         }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:
[V3066](https://www.viva64.com/ru/w/v3066/) Possible incorrect order of arguments passed to 'IsAlive' method: 'defender' and 'attacker'. [Fight2.cs 117](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3066_fix?expand=1#diff-1b3dc83f328a580014b30b1f826eb818L117)
[V3066](https://www.viva64.com/ru/w/v3066/) Possible incorrect order of arguments passed to 'StartFight' method: 'defender' and 'attacker'. [Fight2.cs 126](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3066_fix?expand=1#diff-1b3dc83f328a580014b30b1f826eb818L126)
[V3066](https://www.viva64.com/ru/w/v3066/) Possible incorrect order of arguments passed to 'HitTarget' method: 'defender' and 'attacker'. [Fight2.cs 165](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3066_fix?expand=1#diff-1b3dc83f328a580014b30b1f826eb818L126)
[V3066](https://www.viva64.com/ru/w/v3066/) Possible incorrect order of arguments passed to 'updateRoom' method: 'oldRoomData' and 'newRoomData'. [PlayerManager.cs 26](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3066_fix?expand=1#diff-a029321296abfa32e4f2fdabf2317032L26)
[V3066](https://www.viva64.com/ru/w/v3066/) Possible incorrect order of arguments passed to 'updateRoom' method: 'oldRoomData' and 'newRoomData'. [PlayerManager.cs 56](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3066_fix?expand=1#diff-a029321296abfa32e4f2fdabf2317032L56)
[V3066](https://www.viva64.com/ru/w/v3066/) Possible incorrect order of arguments passed to 'updateRoom' method: 'oldRoomData' and 'newRoomData'. [PlayerManager.cs 71](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3066_fix?expand=1#diff-a029321296abfa32e4f2fdabf2317032L71)