### PR TITLE
Fix V3130 warning from PVS-Studio Static Analyzer

### DIFF
--- a/MIMWebClient/Core/Command.cs
+++ b/MIMWebClient/Core/Command.cs
@@ -274,7 +274,7 @@ namespace MIMWebClient.Core
                     commandKey = commands[0] + " " + commands[1];
                     commandOptions = enteredCommand.Substring(enteredCommand.IndexOf(commands[2], StringComparison.Ordinal)).Trim();
                 }
-                else if (commandKey.Equals("c", StringComparison.InvariantCultureIgnoreCase) || commandKey.Equals("cast", StringComparison.InvariantCultureIgnoreCase) && commands.Length > 1)
+                else if ((commandKey.Equals("c", StringComparison.InvariantCultureIgnoreCase) || commandKey.Equals("cast", StringComparison.InvariantCultureIgnoreCase)) && commands.Length > 1)
                 {
                     commandKey = commands[0] + " " + commands[1];
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:
[V3130](https://www.viva64.com/en/w/v3066/) Priority of the '&&' operator is higher than that of the '||' operator. Possible missing parentheses. [Command.cs 277](https://github.com/LiamKenneth/ArchaicQuest/compare/master...spirifoxy:V3130_fix?expand=1#diff-d715ca2b32d234598787df07b83a689fL277)