### PR TITLE
Fix V3114 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/MIMWebClient/Core/Events/Communicate.cs
+++ b/MIMWebClient/Core/Events/Communicate.cs
@@ -255,7 +255,7 @@ namespace MIMWebClient.Core.Events
 
             var discordBot = new HomeController();
             discordBot.PostToDiscord(discordToSay);
-
+            discordBot.Dispose();
 
         }
 
@@ -289,7 +289,7 @@ namespace MIMWebClient.Core.Events
 
             var discordBot = new HomeController();
             discordBot.PostToDiscord(discordToSay);
-
+            discordBot.Dispose();
         }
 
     }

--- a/MIMWebClient/Core/Player/Experience.cs
+++ b/MIMWebClient/Core/Player/Experience.cs
@@ -114,6 +114,7 @@ namespace MIMWebClient.Core.Player
 
                 var discordBot = new HomeController();
                 discordBot.PostToDiscord(discordToSay);
+                discordBot.Dispose();
             }
         }
 

--- a/MIMWebClient/Hubs/MIMHub.cs
+++ b/MIMWebClient/Hubs/MIMHub.cs
@@ -366,8 +366,8 @@ namespace MIMWebClient.Hubs
             var discordToSay = "A new character called, " + PlayerData.Name + " has entered the realm.";
 
             var discordBot = new HomeController();
-             discordBot.PostToDiscord(discordToSay);
-
+            discordBot.PostToDiscord(discordToSay);
+            discordBot.Dispose();
         }
 
         public void Login(string id, string name, string password)
@@ -446,7 +446,7 @@ namespace MIMWebClient.Hubs
 
                 var discordBot = new HomeController();
                 discordBot.PostToDiscord(discordToSay);
-
+                discordBot.Dispose();
 
 
             }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:
[V3114](https://www.viva64.com/en/w/v3114/) IDisposable object 'discordBot' is not disposed before method returns. Communicate.cs 256
[V3114](https://www.viva64.com/en/w/v3114/) IDisposable object 'discordBot' is not disposed before method returns. Communicate.cs 290
[V3114](https://www.viva64.com/en/w/v3114/) IDisposable object 'discordBot' is not disposed before method returns. Experience.cs 115
[V3114](https://www.viva64.com/en/w/v3114/) IDisposable object 'discordBot' is not disposed before method returns. MIMHub.cs 368
[V3114](https://www.viva64.com/en/w/v3114/) IDisposable object 'discordBot' is not disposed before method returns. MIMHub.cs 447